### PR TITLE
Show qunit output when tests fail

### DIFF
--- a/qunit_tests/tests/__init__.py
+++ b/qunit_tests/tests/__init__.py
@@ -38,4 +38,4 @@ class QUnitTestCase(SimpleTestCase):
     def run_test(self, test):
         asrts = test.find_elements_by_xpath('.//li')
         for asrt in asrts:
-            self.assertEqual(test.get_attribute('class'), 'pass')
+            self.assertEqual(test.get_attribute('class'), 'pass', test.text)


### PR DESCRIPTION
Currently if a qunit tests fail you get a rather unhelpful 'pass' != 'fail' message.
Instead this outputs the text from the failed test (formatted badly, but it's better than nothing)
